### PR TITLE
Extend warning

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -13,7 +13,7 @@ warn ""
 warn "If you got this installer from a tutorial, you're probably"
 warn "not expert enough."
 warn ""
-warn "Press any key to continue"
+warn "Press any key to continue or control + c to quit"
 read
 
 ARCH=$(uname -m)

--- a/installer.sh
+++ b/installer.sh
@@ -4,7 +4,17 @@ set -e
 function error { echo -e "[Error] $*"; exit 1; }
 function warn  { echo -e "[Warning] $*"; }
 
-warn "This way to run Home Assistant is carfully and should be only used if the OS is not possible to run!"
+warn "This installer of Home Assistant is for experts only!"
+warn ""
+warn "This method is not supported by the Home Assistant team."
+warn "You need to solve any issue you run into while installing"
+warn "or updating Home Assistant yourself."
+warn ""
+warn "If you got this installer from a tutorial, you're probably"
+warn "not expert enough."
+warn ""
+warn "Press any key to continue"
+read
 
 ARCH=$(uname -m)
 DOCKER_BINARY=/usr/bin/docker


### PR DESCRIPTION
Extend the warning that is printed when the installer is invoked. Require a key press to acknowledge the warning.