### PR TITLE
Mount the dockerconfig into the supervisor container

### DIFF
--- a/files/hassio-supervisor
+++ b/files/hassio-supervisor
@@ -29,6 +29,7 @@ runSupervisor() {
         $APPARMOR \
         --security-opt seccomp=unconfined \
         -v /run/docker.sock:/run/docker.sock \
+        -v ~/.docker/config.json:/etc/dockerconfig \
         -v /run/dbus:/run/dbus \
         -v /etc/machine-id:/etc/machine-id:ro \
         -v "${HASSIO_DATA}":/data:rw \


### PR DESCRIPTION
Related to: https://github.com/home-assistant/supervisor/pull/2038

I'm not entirely sure about the mounting from homedir, maybe it's better to ask the user to copy the JSON file to the HASSIO_DATA folder and then this PR isn't needed at all.