### PR TITLE
Update example to not pipe curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This method is considered advanced and should only be used if one is an expert i
 Run as root (sudo su):
 
 ```bash
-wget https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh
+curl -Lo installer.sh https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh
 bash installer.sh
 ```
 
@@ -30,7 +30,7 @@ bash installer.sh
 you can set these parameters by appending ` --<parameter> <value>` like:
 
 ```bash
-wget https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh
+curl -Lo installer.sh https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh
 bash installer.sh --mmachine MY_MACHINE
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This method is considered advanced and should only be used if one is an expert i
 Run as root (sudo su):
 
 ```bash
-curl -sL https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh | bash -s
+wget https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh
+bash installer.sh
 ```
 
 ### Command line arguments
@@ -26,10 +27,11 @@ curl -sL https://raw.githubusercontent.com/home-assistant/supervised-installer/m
 | -p \| --prefix     | /usr                 | Binary prefix for hass.io installation                 |
 | -s \| --sysconfdir | /etc                 | Configuration directory for hass.io installation       |
 
-you can set these parameters by appending ` -- <parameter> <value>` like:
+you can set these parameters by appending ` --<parameter> <value>` like:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh | bash -s -- -m MY_MACHINE
+wget https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh
+bash installer.sh --mmachine MY_MACHINE
 ```
 
 ## Supported Machine types


### PR DESCRIPTION
Since there is now a read in the script, piping the curl to bash gives one of the following:
- It waits forever and does not accept input
- It breaks at that point
- It skips it completely

This changes the examples to download first, then executing with bash