### PR TITLE
Correct and standardize package names

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -106,7 +106,7 @@ warn "Changes are needed to the /etc/network/interfaces file"
 info "If you have modified the network on the host manualy, those can now be overwritten"
 info "If you do not overwrite this now you need to manually adjust it later"
 info "Do you want to proceed with that? [N/y] "
-read answer
+read answer < /dev/tty
 
 if [[ "$answer" =~ "y" ]] || [[ "$answer" =~ "Y" ]]; then
     info "Replacing /etc/network/interfaces"

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-declare -a MISSING_PACAKGES
+declare -a MISSING_PACKGES
 
 function info { echo -e "\e[32m[info] $*\e[39m"; }
 function warn  { echo -e "\e[33m[warn] $*\e[39m"; }
@@ -47,20 +47,20 @@ URL_SERVICE_HASSIO="${URL_RAW_BASE}/hassio-supervisor.service"
 URL_APPARMOR_PROFILE="https://version.home-assistant.io/apparmor.txt"
 
 # Check env
-command -v systemctl > /dev/null 2>&1 || MISSING_PACAKGES+=("systemd")
-command -v nmcli > /dev/null 2>&1 || MISSING_PACAKGES+=("network-manager")
-command -v apparmor_parser > /dev/null 2>&1 || MISSING_PACAKGES+=("apparmor")
-command -v docker > /dev/null 2>&1 || MISSING_PACAKGES+=("docker")
-command -v jq > /dev/null 2>&1 || MISSING_PACAKGES+=("jq")
-command -v curl > /dev/null 2>&1 || MISSING_PACAKGES+=("curl")
-command -v avahi-daemon > /dev/null 2>&1 || MISSING_PACAKGES+=("avahi-daemon")
-command -v dbus-daemon > /dev/null 2>&1 || MISSING_PACAKGES+=("dbus")
+command -v systemctl > /dev/null 2>&1 || MISSING_PACKAGES+=("systemd")
+command -v nmcli > /dev/null 2>&1 || MISSING_PACKAGES+=("network-manager")
+command -v apparmor_parser > /dev/null 2>&1 || MISSING_PACKAGES+=("apparmor")
+command -v docker > /dev/null 2>&1 || MISSING_PACKAGES+=("docker")
+command -v jq > /dev/null 2>&1 || MISSING_PACKAGES+=("jq")
+command -v curl > /dev/null 2>&1 || MISSING_PACKAGES+=("curl")
+command -v avahi-daemon > /dev/null 2>&1 || MISSING_PACKAGES+=("avahi-daemon")
+command -v dbus-daemon > /dev/null 2>&1 || MISSING_PACKAGES+=("dbus")
 
 
-if [ ! -z "${MISSING_PACAKGES}" ]; then
+if [ ! -z "${MISSING_PACKAGES}" ]; then
     warn "The following is missing on the host and needs "
     warn "to be installed and configured before running this script again"
-    error "missing: ${MISSING_PACAKGES[@]}"
+    error "missing: ${MISSING_PACKAGES[@]}"
 fi
 
 # Check if Modem Manager is enabled

--- a/installer.sh
+++ b/installer.sh
@@ -106,7 +106,7 @@ warn "Changes are needed to the /etc/network/interfaces file"
 info "If you have modified the network on the host manualy, those can now be overwritten"
 info "If you do not overwrite this now you need to manually adjust it later"
 info "Do you want to proceed with that? [N/y] "
-read answer < /dev/tty
+read answer
 
 if [[ "$answer" =~ "y" ]] || [[ "$answer" =~ "Y" ]]; then
     info "Replacing /etc/network/interfaces"

--- a/installer.sh
+++ b/installer.sh
@@ -48,12 +48,12 @@ URL_APPARMOR_PROFILE="https://version.home-assistant.io/apparmor.txt"
 
 # Check env
 command -v systemctl > /dev/null 2>&1 || MISSING_PACAKGES+=("systemd")
-command -v nmcli > /dev/null 2>&1 || MISSING_PACAKGES+=("NetworkManager")
-command -v apparmor_parser > /dev/null 2>&1 || MISSING_PACAKGES+=("AppArmor")
+command -v nmcli > /dev/null 2>&1 || MISSING_PACAKGES+=("network-manager")
+command -v apparmor_parser > /dev/null 2>&1 || MISSING_PACAKGES+=("apparmor")
 command -v docker > /dev/null 2>&1 || MISSING_PACAKGES+=("docker")
 command -v jq > /dev/null 2>&1 || MISSING_PACAKGES+=("jq")
 command -v curl > /dev/null 2>&1 || MISSING_PACAKGES+=("curl")
-command -v avahi-daemon > /dev/null 2>&1 || MISSING_PACAKGES+=("avahi")
+command -v avahi-daemon > /dev/null 2>&1 || MISSING_PACAKGES+=("avahi-daemon")
 command -v dbus-daemon > /dev/null 2>&1 || MISSING_PACAKGES+=("dbus")
 
 


### PR DESCRIPTION
Some of the package names are incorrect (NetworkManager, avahi) or unnecessarily upper-cased (AppArmor). Standardize all package names to ones available in Debian stable repositories.
```bash
root@hass01:~# for PACKAGE in systemd network-manager apparmor docker jq curl avahi-daemon dbus; do apt info "${PACKAGE}" 2> /dev/null | grep "^Package:"; done    
Package: systemd
Package: network-manager
Package: apparmor
Package: docker
Package: jq
Package: curl
Package: avahi-daemon
Package: dbus
```
