### PR TITLE
Disabled Random MAC address on Wi-Fi

### DIFF
--- a/files/NetworkManager.conf
+++ b/files/NetworkManager.conf
@@ -9,3 +9,6 @@ unmanaged-devices=type:bridge;type:tun;type:veth
 
 [logging]
 backend=journal
+
+[device]
+wifi.scan-rand-mac-address=no


### PR DESCRIPTION
Disable randomization during Wi-Fi scanning which is enabled by default.
https://wiki.archlinux.org/index.php/NetworkManager#Configuring_MAC_Address_Randomization