### PR TITLE
put privileged option first

### DIFF
--- a/files/hassio-supervisor
+++ b/files/hassio-supervisor
@@ -24,8 +24,8 @@ runSupervisor() {
     docker rm --force hassio_supervisor || true
 
     # shellcheck disable=SC2086
-    docker run --name hassio_supervisor \
-        --privileged \
+    docker run --privileged \
+        --name hassio_supervisor \
         $APPARMOR \
         --security-opt seccomp=unconfined \
         -v /run/docker.sock:/run/docker.sock \


### PR DESCRIPTION
Having the --privileged option first prevents this error when running unsupported supervised hassio on ubuntu 20.04, installed through the installer script.
```
CRITICAL (MainThread) [supervisor.misc.hwmon] Not privileged to run udev monitor!
```
This hasn't been tested on other platforms, but I don't see how this could break them.