### PR TITLE
installer: Support prefixed docker installations (and docker-snap)

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -84,10 +84,10 @@ if [ ! -f "$FILE_DOCKER_CONF" ]; then
 else
   STORAGE_DRIVER=$(docker info -f "{{json .}}" | jq -r -e .Driver)
   LOGGING_DRIVER=$(docker info -f "{{json .}}" | jq -r -e .LoggingDriver)
-  if [[ "$STORAGE_DRIVER" != "overlay2" ]]; then 
+  if [[ "$STORAGE_DRIVER" != "overlay2" ]]; then
     warn "Docker is using $STORAGE_DRIVER and not 'overlay2' as the storage driver, this is not supported."
   fi
-  if [[ "$LOGGING_DRIVER"  != "journald" ]]; then 
+  if [[ "$LOGGING_DRIVER"  != "journald" ]]; then
     warn "Docker is using $LOGGING_DRIVER and not 'journald' as the logging driver, this is not supported."
   fi
 fi

--- a/installer.sh
+++ b/installer.sh
@@ -21,7 +21,7 @@ ARCH=$(uname -m)
 
 IP_ADDRESS=$(hostname -I | awk '{ print $1 }')
 
-BINARY_DOCKER=/usr/bin/docker
+BINARY_DOCKER=$(command -v docker)
 
 DOCKER_REPO=homeassistant
 

--- a/installer.sh
+++ b/installer.sh
@@ -214,6 +214,7 @@ docker tag "$HASSIO_DOCKER:$HASSIO_VERSION" "$HASSIO_DOCKER:latest" > /dev/null
 ##
 # Install Hass.io Supervisor
 info "Install supervisor startup scripts"
+mkdir -p "${PREFIX}/sbin"
 curl -sL ${URL_BIN_HASSIO} > "${PREFIX}/sbin/hassio-supervisor"
 curl -sL ${URL_SERVICE_HASSIO} > "${SYSCONFDIR}/systemd/system/hassio-supervisor.service"
 
@@ -252,6 +253,7 @@ systemctl start hassio-supervisor.service
 ##
 # Setup CLI
 info "Installing the 'ha' cli"
+mkdir -p "${PREFIX}/bin"
 curl -sL ${URL_HA} > "${PREFIX}/bin/ha"
 chmod a+x "${PREFIX}/bin/ha"
 

--- a/installer.sh
+++ b/installer.sh
@@ -22,6 +22,7 @@ ARCH=$(uname -m)
 IP_ADDRESS=$(hostname -I | awk '{ print $1 }')
 
 BINARY_DOCKER=$(command -v docker)
+DOCKER_PREFIX="${BINARY_DOCKER/\/bin\/docker}"
 
 DOCKER_REPO=homeassistant
 
@@ -36,6 +37,8 @@ FILE_NM_CONNECTION="/etc/NetworkManager/system-connections/default"
 if [[ "$BINARY_DOCKER" == "/snap/bin/docker" ]]; then
     SERVICE_DOCKER="snap.docker.dockerd.service"
     FILE_DOCKER_CONF="$(snap run --shell docker -c 'printenv SNAP_DATA')/config/daemon.json"
+elif [[ "$DOCKER_PREFIX" != "/usr" ]]; then
+    FILE_DOCKER_CONF="$DOCKER_PREFIX/$FILE_DOCKER_CONF"
 fi
 
 URL_RAW_BASE="https://raw.githubusercontent.com/home-assistant/supervised-installer/master/files"

--- a/installer.sh
+++ b/installer.sh
@@ -33,6 +33,11 @@ FILE_INTERFACES="/etc/network/interfaces"
 FILE_NM_CONF="/etc/NetworkManager/NetworkManager.conf"
 FILE_NM_CONNECTION="/etc/NetworkManager/system-connections/default"
 
+if [[ "$BINARY_DOCKER" == "/snap/bin/docker" ]]; then
+    SERVICE_DOCKER="snap.docker.dockerd.service"
+    FILE_DOCKER_CONF="$(snap run --shell docker -c 'printenv SNAP_DATA')/config/daemon.json"
+fi
+
 URL_RAW_BASE="https://raw.githubusercontent.com/home-assistant/supervised-installer/master/files"
 URL_VERSION="https://version.home-assistant.io/stable.json"
 URL_BIN_APPARMOR="${URL_RAW_BASE}/hassio-apparmor"

--- a/installer.sh
+++ b/installer.sh
@@ -85,10 +85,10 @@ else
   STORAGE_DRIVER=$(docker info -f "{{json .}}" | jq -r -e .Driver)
   LOGGING_DRIVER=$(docker info -f "{{json .}}" | jq -r -e .LoggingDriver)
   if [[ "$STORAGE_DRIVER" != "overlay2" ]]; then
-    warn "Docker is using $STORAGE_DRIVER and not 'overlay2' as the storage driver, this is not supported."
+    warn "Docker is using $STORAGE_DRIVER and not 'overlay2' as the storage driver, this is not supported. Update your $FILE_DOCKER_CONF accordingly."
   fi
   if [[ "$LOGGING_DRIVER"  != "journald" ]]; then
-    warn "Docker is using $LOGGING_DRIVER and not 'journald' as the logging driver, this is not supported."
+    warn "Docker is using $LOGGING_DRIVER and not 'journald' as the logging driver, this is not supported. Update your $FILE_DOCKER_CONF accordingly."
   fi
 fi
 


### PR DESCRIPTION
It's possible to install HA supervised using docker-snap [1], however
few paths needs to be adjusted accordingly.

In particular the configuration file path is different and so it is the
generated systemd dockerd service.

[1] https://github.com/docker-snap/docker-snap