### PR TITLE
Properly check for enabled ModemManager service

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -63,7 +63,7 @@ if [ ! -z "${MISSING_PACKAGES}" ]; then
 fi
 
 # Check if Modem Manager is enabled
-if systemctl list-unit-files ModemManager.service | grep enabled > /dev/null 2>&1; then
+if systemctl is-enabled ModemManager.service &> /dev/null; then
     warn "ModemManager service is enabled. This might cause issue when using serial devices."
 fi
 


### PR DESCRIPTION
A systemd service may be marked as enabled as vendor preset, and this
breaks the check we used to check if it was active.

Here's what you get in an Ubuntu 20.04 installation:

❯ systemctl status ModemManager
● ModemManager.service - Modem Manager
     Loaded: loaded (/lib/systemd/system/ModemManager.service; disabled; vendor preset: enabled)
     Active: inactive (dead)

❯ systemctl list-unit-files ModemManager.service
UNIT FILE            STATE    VENDOR PRESET
ModemManager.service disabled enabled

1 unit files listed

While the list-unit-files can be filtered using `--state=enabled`, we
can just rely on `systemctl is-enabled` instead.