### PR TITLE
Avoid extraneous NetworkManager restart

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -114,7 +114,7 @@ if [ $(diff ${tmp} ${FILE_INTERFACES} | wc -c) -gt 0 ]; then
   info "If you have modified the network on the host manualy, those can now be overwritten"
   info "If you do not overwrite this now you need to manually adjust it later"
   info "Do you want to proceed with that? [N/y] "
-  read answer < /dev/tty
+  read answer
 
   if [[ "$answer" =~ "y" ]] || [[ "$answer" =~ "Y" ]]; then
     info "Replacing /etc/network/interfaces"

--- a/installer.sh
+++ b/installer.sh
@@ -209,7 +209,16 @@ if [ ! -d "$DATA_SHARE" ]; then
 fi
 
 # Read infos from web
-HASSIO_VERSION=$(curl -sL $URL_VERSION | jq -e -r '.supervisor')
+i=0; while [ ${i} -le 10 ] && [ -z "${HASSIO_VERSION:-}" ]; do
+  HASSIO_VERSION=$(curl -sL $URL_VERSION | jq -e -r '.supervisor')
+  if [ ! -z "${HASSIO_VERSION:-}" ]; then break; fi
+  info "Waiting on ${URL_VERSION}; sleeping for $((i*2)) seconds""
+  sleep $((i*2))
+  i=$((i+1))
+done
+if [ -z "${HASSIO_VERSION:-}" ]; then 
+  error "Unable to retrieve HASSIO_VERSION from ${URL_VERSION}"
+fi
 
 ##
 # Write configuration

--- a/installer.sh
+++ b/installer.sh
@@ -212,7 +212,7 @@ fi
 i=0; while [ ${i} -le 10 ] && [ -z "${HASSIO_VERSION:-}" ]; do
   HASSIO_VERSION=$(curl -sL $URL_VERSION | jq -e -r '.supervisor')
   if [ ! -z "${HASSIO_VERSION:-}" ]; then break; fi
-  info "Waiting on ${URL_VERSION}; sleeping for $((i*2)) seconds""
+  info "Waiting on ${URL_VERSION}; sleeping for $((i*2)) seconds"
   sleep $((i*2))
   i=$((i+1))
 done


### PR DESCRIPTION
On at least one installation using the original script (ubuntu18.04.5 on amd64) the restart of NetworkManager service caused a reset of Wifi connectivity which precluded the successul download of the required `stable.json` file as well as the corresponding images, had they been properly decorated with the version.

This change tests for differences between the existing file relevant to a NetworkManager restart and only restarts the NetworkManager when changes are detected; prior logic requesting approval remain in-place should differences arise.

In addition, a five (5) second sleep has been introduced after the NetworkManager restart to accomodate devices which perform a reset on their network connections.
