### PR TITLE
Create bin folders when they do not exist

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -192,6 +192,13 @@ if [ ! -d "$DATA_SHARE" ]; then
     mkdir -p "$DATA_SHARE"
 fi
 
+if [ ! -d "${PREFIX}/sbin" ]; then
+    mkdir -p "${PREFIX}/sbin"
+fi
+
+if [ ! -d "${PREFIX}/bin" ]; then
+    mkdir -p "${PREFIX}/bin"
+fi
 # Read infos from web
 HASSIO_VERSION=$(curl -s $URL_VERSION | jq -e -r '.supervisor')
 


### PR DESCRIPTION
When using another prefix then /usr the bin folders are used, but not created