### PR TITLE
Make aarch64 machine type work as well on Ubuntu Server 64bit install for Raspberry Pi

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -181,7 +181,7 @@ case $ARCH in
     ;;
 esac
 
-if [[ ! "${MACHINE}" =~ ^(intel-nuc|odroid-c2|odroid-n2|odroid-xu|qemuarm|qemuarm-64|qemux86|qemux86-64|raspberrypi|raspberrypi2|raspberrypi3|raspberrypi4|raspberrypi3-64|raspberrypi4-64|tinker)$ ]]; then
+if [[ ! "${MACHINE}" =~ ^(intel-nuc|odroid-c2|odroid-n2|odroid-xu|qemuarm|qemuarm-64|qemux86|qemux86-64|raspberrypi|raspberrypi2|raspberrypi3|raspberrypi4|raspberrypi3-64|raspberrypi4-64|tinker|aarch64)$ ]]; then
     error "Unknown machine type ${MACHINE}!"
 fi
 


### PR DESCRIPTION
If you install ubuntu 64bit server on raspberry pi and use 

--machine aarch64 

as commandline option.