### PR TITLE
Update installer.sh to wait on network connection after restart

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -115,6 +115,9 @@ fi
 info "Restarting NetworkManager"
 systemctl restart "${SERVICE_NM}"
 
+info "Waiting for network connection"
+until ping -c 1 -n -w 1 www.docker.io 2> /dev/null | grep "bytes of data" 2&1> /dev/null; do sleep 2; done
+
 # Parse command line parameters
 while [[ $# -gt 0 ]]; do
     arg="$1"


### PR DESCRIPTION
I had the same problem as some others, and hacked away at this solution for some time.
- Typing `stop` & `start` seems to wait for the process to come up in terminal, but not when it's in a bash script apparently.
- Just waiting with `systemctl status NetworkManager` didn't do the trick, so I used ping.
- The redirects (`2>` and `2&1>`) are not to echo the ping/grep outputs to stdout
- put the sleep on 2 seconds, to not spam the chosen server

I was wondering if I should use `www.home-assistant.io` as the ping target. 🤔