### PR TITLE
Add apparmor-utils to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ avahi-daemon \
 udisks2 \
 libglib2.0-bin \
 network-manager \
-dbus -y
+dbus \
+avahi-daemon -y
 ```
 
 Step 2: Install Docker-CE with the following command:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ udisks2 \
 libglib2.0-bin \
 network-manager \
 dbus \
-avahi-daemon -y
+apparmor-utils -y
 ```
 
 Step 2: Install Docker-CE with the following command:


### PR DESCRIPTION
Stock Debian 11 generic PC install requires `apparmor-utils`

```
Unpacking homeassistant-supervised (1.0.1) ...
dpkg: dependency problems prevent configuration of homeassistant-supervised:
 homeassistant-supervised depends on apparmor; however:
  Package apparmor is not installed.
```