### PR TITLE
Adusted d/control to handle setup using the Debian Docker packages

### DIFF
--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -3,7 +3,7 @@ Section: base
 Version: 1.0.2
 Priority: optional
 Architecture: all
-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent
+Depends: curl, bash, docker-ce | docker.io, dbus, network-manager, apparmor, jq, systemd, os-agent
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised


### PR DESCRIPTION
Docker in Debian is called docker.io, and is a tested alternative for
setting up Home Assistant Supervisor and friends.