### PR TITLE
Remove the os-agent from depends list and add it as a suggestion

### DIFF
--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -1,9 +1,10 @@
 Package: homeassistant-supervised
 Section: base
-Version: 1.0.2
+Version: 1.0.3
 Priority: optional
 Architecture: all
-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent
+Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd
+Suggests: os-agent
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised


### PR DESCRIPTION
resolves issues:
https://github.com/home-assistant/supervised-installer/issues/185
https://github.com/home-assistant/os-agent/issues/57
https://github.com/home-assistant/os-agent/issues/63