### PR TITLE
Streamline hassio-supervisor.service

### DIFF
--- a/homeassistant-supervised/etc/systemd/system/hassio-supervisor.service
+++ b/homeassistant-supervised/etc/systemd/system/hassio-supervisor.service
@@ -1,7 +1,12 @@
 [Unit]
 Description=Hass.io supervisor
-Requires=%%SERVICE_DOCKER%%
-After=%%SERVICE_DOCKER%% dbus.socket
+Requires=docker.service dbus.service
+Wants=network-online.target hassio-apparmor.service time-sync.target
+After=docker.service dbus.service network-online.target hassio-apparmor.service time-sync.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+ConditionPathExists=/run/dbus/system_bus_socket
+ConditionPathExists=/run/docker.sock
 
 [Service]
 Type=simple


### PR DESCRIPTION
I ignore for now the systemd-journal-gatewayd.socket - maybe we want that also have once on the supervised to get all logs from host