### PR TITLE
Add check for /boot/cmdline.txt

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -152,7 +152,7 @@ then
     if ! grep -q "systemd.unified_cgroup_hierarchy=false" /boot/cmdline.txt; then
         info "Switching to cgroup v1"
         cp /boot/cmdline.txt /boot/cmdline.txt.bak
-        sed -i 's/$/systemd.unified_cgroup_hierarchy=false/' /boot/cmdline.txt
+        sed -i 's/$/ systemd.unified_cgroup_hierarchy=false/' /boot/cmdline.txt
         touch /var/run/reboot-required
     fi
 else

--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -138,14 +138,26 @@ info "Installing the 'ha' cli"
 chmod a+x "${PREFIX}/bin/ha"
 
 # Switch to cgroup v1
-if ! grep -q "systemd.unified_cgroup_hierarchy=false" /etc/default/grub; then
-    info "Switching to cgroup v1"
-    cp /etc/default/grub /etc/default/grub.bak
-    sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT="/&systemd.unified_cgroup_hierarchy=false /' /etc/default/grub
-    update-grub
-    touch /var/run/reboot-required
+if [ -f /etc/default/grub ]
+then
+    if ! grep -q "systemd.unified_cgroup_hierarchy=false" /etc/default/grub; then
+        info "Switching to cgroup v1"
+        cp /etc/default/grub /etc/default/grub.bak
+        sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT="/&systemd.unified_cgroup_hierarchy=false /' /etc/default/grub
+        update-grub
+        touch /var/run/reboot-required
+    fi
+elif [ -f /boot/cmdline.txt ]
+then
+    if ! grep -q "systemd.unified_cgroup_hierarchy=false" /boot/cmdline.txt; then
+        info "Switching to cgroup v1"
+        cp /boot/cmdline.txt /boot/cmdline.txt.bak
+        sed -i 's/$/systemd.unified_cgroup_hierarchy=false/' /boot/cmdline.txt
+        touch /var/run/reboot-required
+    fi
+else
+    warn "Could not find /etc/default/grub or /boot/cmdline.txt failed to switch to cgroup v1"
 fi
-
 info "Within a few minutes you will be able to reach Home Assistant at:"
 info "http://homeassistant.local:8123 or using the IP address of your"
 info "machine: http://${IP_ADDRESS}:8123"


### PR DESCRIPTION
Hopefully this will fix the error some are facing in regards to setting cgroupv1 on Raspberry Pi
I would greatly apricate it if someone could help me test this as I currently do not have access to a Raspberry Pi running Debian

Debian package can be found here:
https://github.com/home-assistant/supervised-installer/actions/runs/2086587575