### PR TITLE
Add log-opts to Docker Daemon

### DIFF
--- a/homeassistant-supervised/etc/docker/daemon.json
+++ b/homeassistant-supervised/etc/docker/daemon.json
@@ -2,5 +2,8 @@
     "log-driver": "journald",
     "storage-driver": "overlay2",
     "ip6tables": true,
-    "experimental": true
+    "experimental": true,
+    "log-opts": {
+        "tag": "{{.Name}}"
+    }
 }


### PR DESCRIPTION
Add log-opts to Docker Daemon as per the changes in https://github.com/home-assistant/architecture/pull/801