### PR TITLE
docs: Add documentation about how to reconfigure "$DATA_SHARE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ dpkg -i homeassistant-supervised.deb
 - tinker
 - khadas-vim3
 
+## Configuration
+
+The default path for our `$DATA_SHARE` is `/usr/share/hassio`.
+This path is used to store all home assistant related things.
+
+You can reconfigure this path during installation with
+
+```bash
+DATA_SHARE=/my/own/homeassistant dpkg --force-confdef --force-confold -i /srv/setup/homeassistant-supervised.deb
+```
+
 ## Troubleshooting
 
 If something's going wrong, use `journalctl -f` to get your system logs. If you are not familiar with Linux and how you can fix issues, we recommend to use our Home Assistant OS.


### PR DESCRIPTION
I was looking into how I can reconfigure the path where all the things get installed.
I found https://github.com/home-assistant/supervised-installer/issues/187 and it worked pretty well.

This Pull Request adds a small part for documentation about the `$DATA_SHARE` variable.