### PR TITLE
Added information for RPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ wget https://github.com/home-assistant/supervised-installer/releases/latest/down
 dpkg -i homeassistant-supervised.deb
 ```
 
+On a Raspberry PI additionally add `systemd.unified_cgroup_hierarchy=false` to the file `/boot/cmdline.txt` that the CGroup Version 1 is used.
+
 ## Supported Machine types
 
 - generic-x86-64


### PR DESCRIPTION
## Proposed change
Added useful information to fix wrong CGroup Version on a RaspberryPI. 

## Additional information

The information I found here:
https://community.home-assistant.io/t/ha-supervised-how-to-move-from-unsupported-to-supported/475977/17
https://community.home-assistant.io/t/updated-to-latest-supervisor-and-despite-mentioned-changes-still-get-unsupported-installation/437235/20

