### PR TITLE
Block Unsupported OS

### DIFF
--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -10,6 +10,18 @@ warn "Home Assistant as a VM or run Home Assistant Core"
 warn "via a Docker container."
 warn ""
 
+# Check if we are running on a supported OS
+CURRENT_OS=$(lsb_release -d)
+if [[ $CURRENT_OS != *"Debian GNU/Linux 11 (bullseye)"* ]]; then
+    error "Unsupported OS: $CURRENT_OS"
+fi
+
+# Check if we are running on a supported architecture
+ARCH=$(uname -m)
+if [[ ! "i386|i686|x86_64|arm|armv6l|armv7l|aarch64" == *"$ARCH"* ]]; then
+    error "${ARCH} is not supported!"
+fi
+
 # Check if Modem Manager is enabled
 if systemctl is-enabled ModemManager.service &> /dev/null; then
     warn "ModemManager service is enabled. This might cause issue when using serial devices."
@@ -22,10 +34,6 @@ if [[ "$(sysctl --values kernel.dmesg_restrict)" != "0" ]]; then
     echo "kernel.dmesg_restrict=0" >> /etc/sysctl.conf
 fi
 
-ARCH=$(uname -m)
-if [[ ! "i386|i686|x86_64|arm|armv6l|armv7l|aarch64" == *"$ARCH"* ]]; then
-    error "${ARCH} is not supported!"
-fi
 
 
 dpkg-divert --package homeassistant-supervised --add --rename \

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -11,9 +11,17 @@ warn "via a Docker container."
 warn ""
 
 # Check if we are running on a supported OS
+BYPASS_OS_CHECK=${BYPASS_OS_CHECK:-false}
 CURRENT_OS=$(lsb_release -d)
 if [[ $CURRENT_OS != *"Debian GNU/Linux 11 (bullseye)"* ]]; then
-    error "${CURRENT_OS} is not supported!"
+# Strip first feild of string
+    CURRENT_OS=$(echo $CURRENT_OS | cut -d' ' -f2-)
+    if [[ $BYPASS_OS_CHECK != "true" ]]; then
+        error "${CURRENT_OS} is not supported!"
+    fi
+    warn "Bypassing OS check..."
+    warn "${CURRENT_OS} is not supported!"
+    warn "Please DO NOT report issues regarding this OS!"
 fi
 
 # Check if we are running on a supported architecture

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -13,7 +13,7 @@ warn ""
 # Check if we are running on a supported OS
 CURRENT_OS=$(lsb_release -d)
 if [[ $CURRENT_OS != *"Debian GNU/Linux 11 (bullseye)"* ]]; then
-    error "Unsupported OS: $CURRENT_OS"
+    error "${CURRENT_OS} is not supported!"
 fi
 
 # Check if we are running on a supported architecture


### PR DESCRIPTION
The aim of this PR is to block the installation of the HA supervised packaged on unsupported OS's.
Hopefully this will cut down on the number of bug reports on unsupported systems