### PR TITLE
Add lsb-release dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ udisks2 \
 libglib2.0-bin \
 network-manager \
 dbus \
+lsb-release \
 systemd-journal-remote -y
 ```
 


### PR DESCRIPTION
Not all Debian Installations come with lsb-release, therefore installation may fail in select cases. Adding the dependency to the list resolves possible complications.