### PR TITLE
Add support for Armbian OS

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -166,6 +166,14 @@ then
         sed -i.bak 's/$/ systemd.unified_cgroup_hierarchy=false/' /boot/firmware/cmdline.txt
         touch /var/run/reboot-required
     fi
+elif [ -f /boot/uEnv.txt ]
+then
+    if ! grep -q "systemd.unified_cgroup_hierarchy=false" /boot/uEnv.txt; then
+        info "Switching to cgroup v1 and enable apparmor"
+        cp /boot/uEnv.txt /boot/uEnv.txt.bak
+        sed -i 's/^APPEND="/&systemd.unified_cgroup_hierarchy=false apparmor=1 security=apparmor /' /boot/uEnv.txt
+        touch /var/run/reboot-required
+    fi	
 else
     warn "Could not find /etc/default/grub or /boot/firmware/cmdline.txt failed to switch to cgroup v1"
 fi


### PR DESCRIPTION
Switching cgroup v1  and enable apparmor for Armbian OS that use /boot/uEnv.txt

uEnv.txt
LINUX=/zImage
INITRD=/uInitrd
FDT=/dtb/amlogic/meson-sm1-x96-max-plus.dtb
APPEND=root=UUID=9340a604-5f53-414b-81fd-27cfe985b9c0 rootflags=data=writeback rw rootfstype=ext4 console=ttyAML0,115200n8 console=tty0 no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1 systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor