### PR TITLE
Set bind propagation for supervisor data

### DIFF
--- a/homeassistant-supervised/usr/sbin/hassio-supervisor
+++ b/homeassistant-supervised/usr/sbin/hassio-supervisor
@@ -87,7 +87,7 @@ if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
         -v /run/supervisor:/run/os:rw \
         -v /run/udev:/run/udev:ro \
         -v /etc/machine-id:/etc/machine-id:ro \
-        -v ${SUPERVISOR_DATA}:/data:rw \
+        -v ${SUPERVISOR_DATA}:/data:rw,slave \
         -e SUPERVISOR_SHARE=${SUPERVISOR_DATA} \
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_MACHINE=${SUPERVISOR_MACHINE} \


### PR DESCRIPTION
Currently, we can't use the new network storage option from 2023.06:

![current](https://github.com/home-assistant/supervised-installer/assets/186349/1e5c61f5-2f55-4fd1-b694-2ea3ae7e9316)

This PR is just a verbatim port of the PR for hassos https://github.com/home-assistant/operating-system/pull/2557:

![change](https://github.com/home-assistant/supervised-installer/assets/186349/6a872fde-2f54-4221-b845-4f896c485233)
