### PR TITLE
postinst: Do not override hassio.json data if already set

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -106,8 +106,13 @@ case ${ARCH} in
 esac
 PREFIX=${PREFIX:-/usr}
 SYSCONFDIR=${SYSCONFDIR:-/etc}
-DATA_SHARE=${DATA_SHARE:-$PREFIX/share/hassio}
 CONFIG="${SYSCONFDIR}/hassio.json"
+
+if [ -z "$DATA_SHARE" ] && [ -e "$CONFIG" ]; then
+    DATA_SHARE=$(jq -e -r '.data' "${CONFIG}" || true)
+fi
+
+DATA_SHARE=${DATA_SHARE:-$PREFIX/share/hassio}
 cat > "${CONFIG}" <<- EOF
 {
     "supervisor": "${HASSIO_DOCKER}",


### PR DESCRIPTION
On upgrades, if $DATA_SHARE Is not provided we may end up overwriting the user configuration, especially in case the postinst script is triggered as part of dpkg configure because of previous failures (as it may happen in  recent systemd-journal-remote failures).

To prevent this, read the user value if set and re-use it unless a new one is provided.