### PR TITLE
Add Support For Debian Bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ libglib2.0-bin \
 network-manager \
 dbus \
 lsb-release \
-systemd-journal-remote -y
+systemd-journal-remote \
+systemd-resolved -y
 ```
 
 Step 2: Install Docker-CE with the following command:

--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -3,7 +3,7 @@ Section: base
 Version: 1.4.3
 Priority: optional
 Architecture: all
-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote
+Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -12,10 +12,19 @@ warn ""
 
 # Check if we are running on a supported OS
 BYPASS_OS_CHECK=${BYPASS_OS_CHECK:-false}
-CURRENT_OS=$(lsb_release -d)
-if [[ $CURRENT_OS != *"Debian GNU/Linux 11 (bullseye)"* ]]; then
-# Strip first feild of string
-    CURRENT_OS=$(echo $CURRENT_OS | cut -d' ' -f2-)
+supported_os=("Debian GNU/Linux 11 (bullseye)" "Debian GNU/Linux 12 (bookworm)")
+
+CURRENT_OS=$(lsb_release -d | awk -F"\t" '{print $2}')
+os_supported=false
+
+for os in "${supported_os[@]}"; do
+    if [[ $os == "$CURRENT_OS" ]]; then
+        os_supported=true
+        break
+    fi
+done
+
+if [[ $os_supported == false ]]; then
     if [[ $BYPASS_OS_CHECK != "true" ]]; then
         error "${CURRENT_OS} is not supported!"
     fi


### PR DESCRIPTION
Add support for Debian Bookworm while maintaining the 4 months of support for Bullseye as stated by the [ADR](https://github.com/home-assistant/architecture/blob/master/adr/0014-home-assistant-supervised.md)
Supervisor PR: https://github.com/home-assistant/supervisor/pull/4377
Closes: https://github.com/home-assistant/supervised-installer/issues/296