### PR TITLE
Do less strict check for supported os

### DIFF
--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -12,13 +12,13 @@ warn ""
 
 # Check if we are running on a supported OS
 BYPASS_OS_CHECK=${BYPASS_OS_CHECK:-false}
-supported_os=("Debian GNU/Linux 11 (bullseye)" "Debian GNU/Linux 12 (bookworm)")
+supported_os=("bullseye" "bookworm")
 
 CURRENT_OS=$(lsb_release -d | awk -F"\t" '{print $2}')
 os_supported=false
 
 for os in "${supported_os[@]}"; do
-    if [[ $os == "$CURRENT_OS" ]]; then
+    if [[ "$CURRENT_OS" =~ "$os" ]]; then
         os_supported=true
         break
     fi


### PR DESCRIPTION
Do less strict check for supported os:
some distributions based on debian changes lsb_release information, while retain debian codename in this info. They are completely similar to the original debian (e.g., Armbian, which only changes the kernel/uboot packages to run on single-board systems).