### PR TITLE
Add Support For Ubuntu 22.04.3 LTS

### DIFF
--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -3,7 +3,8 @@ Section: base
 Version: 1.5.0
 Priority: optional
 Architecture: all
-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved
+Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote
+Recommends: systemd-resolved
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -12,7 +12,7 @@ warn ""
 
 # Check if we are running on a supported OS
 BYPASS_OS_CHECK=${BYPASS_OS_CHECK:-false}
-supported_os=("Debian GNU/Linux 11 (bullseye)" "Debian GNU/Linux 12 (bookworm)")
+supported_os=("Debian GNU/Linux 11 (bullseye)" "Debian GNU/Linux 12 (bookworm)" "Ubuntu 22.04.3 LTS")
 
 CURRENT_OS=$(lsb_release -d | awk -F"\t" '{print $2}')
 os_supported=false


### PR DESCRIPTION
systemd-resolved move from Depends to Recommends because systemd-resolved is installed by default as part of the systemd package in Ubuntu 22.04.3 LTS