### PR TITLE
Add tasks.json to make testing easier

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Debian Package",
+            "type": "shell",
+            "command": "chmod 555 homeassistant-supervised/DEBIAN/p* && dpkg-deb --build --root-owner-group homeassistant-supervised",
+            "problemMatcher": [],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds "Build Debian Package" as the default task in vscode 