### PR TITLE
Only attach TTY for hassio_cli wrapper when not completing command

### DIFF
--- a/homeassistant-supervised/usr/bin/ha
+++ b/homeassistant-supervised/usr/bin/ha
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2048,SC2086
 
-docker exec -t hassio_cli ha $*
+if [ "$1" != "__complete" ]; then
+    use_tty="-t"
+else
+    use_tty=""
+fi
+
+docker exec ${use_tty} hassio_cli ha $*


### PR DESCRIPTION
Fixes issue with (bash) completion introduced by https://github.com/home-assistant/supervised-installer/pull/332 (Sorry 🙈)