### PR TITLE
Pull latest stable Supervisor if image is missing

### DIFF
--- a/homeassistant-supervised/usr/sbin/hassio-supervisor
+++ b/homeassistant-supervised/usr/sbin/hassio-supervisor
@@ -37,21 +37,28 @@ touch ${SUPERVISOR_STARTUP_MARKER}
 if [ -z "${SUPERVISOR_IMAGE_ID}" ]; then
     # Get the latest from update information
     # Using updater information instead of config. If the config version is
-    # broken, this creates a way (e.g., bad release).
-    SUPERVISOR_VERSION=$(jq -r '.supervisor // "latest"' "${SUPERVISOR_DATA}/updater.json" || echo "latest")
+    # broken, this creates a way back (e.g., bad release).
+    SUPERVISOR_VERSION=$(jq -r '.supervisor // "stable"' "${SUPERVISOR_DATA}/updater.json" || echo "stable")
+
+    # Get version from stable channel in case we have no local version
+    # information.
+    if [ "${SUPERVISOR_VERSION}" = "stable" ]; then
+        SUPERVISOR_VERSION="$(curl -s --location https://version.home-assistant.io/stable.json | jq -e -r '.supervisor')"
+    fi
 
     echo "[WARNING] Supervisor image missing, downloading a fresh one: ${SUPERVISOR_VERSION}"
 
     # Pull in the Supervisor
     if docker pull "${SUPERVISOR_IMAGE}:${SUPERVISOR_VERSION}"; then
-        # Tag as latest if versioned
-        if [ "${SUPERVISOR_VERSION}" != "latest" ]; then
-            docker tag "${SUPERVISOR_IMAGE}:${SUPERVISOR_VERSION}" "${SUPERVISOR_IMAGE}:latest"
-        fi
+        # Tag as latest
+        docker tag "${SUPERVISOR_IMAGE}:${SUPERVISOR_VERSION}" "${SUPERVISOR_IMAGE}:latest"
     else
-        # Pull failed, updater info might be corrupted, re-trying with latest
-        echo "[WARNING] Supervisor downloading failed trying: latest"
-        docker pull "${SUPERVISOR_IMAGE}:latest"
+        # Pull failed, updater info might be corrupted or the release might have
+	# been removed from the container registry, delete the updater info
+	# to start from scratch on next try.
+        echo "[ERROR] Supervisor downloading failed."
+        rm -f "${SUPERVISOR_DATA}/updater.json"
+        exit 1
     fi
 
     SUPERVISOR_IMAGE_ID=$(docker inspect --format='{{.Id}}' "${SUPERVISOR_IMAGE}" || echo "")


### PR DESCRIPTION
Similar to Home Assistant OS if the Supervisor is missing, make sure to pull the latest stable image.

See also https://github.com/home-assistant/operating-system/pull/2765

Fixes: https://github.com/home-assistant/supervised-installer/issues/335