### PR TITLE
Workaround to allow installation on Debian 11

### DIFF
--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -3,7 +3,7 @@ Section: base
 Version: 1.5.0
 Priority: optional
 Architecture: all
-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved, nfs-common, cifs-utils
+Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved | systemd (>=247.3-7+deb11), nfs-common, cifs-utils
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised


### PR DESCRIPTION
`systemd-resolved` is not a package on Debian 11, it is instead included in `systemd` this is the easiest way I could find to workaround this issue. 
Closes #304 #321 #323 #286