### PR TITLE
Cleanup container and stop services before installing

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -19,6 +19,9 @@ URL_VERSION="https://version.home-assistant.io/stable.json"
 HASSIO_VERSION=$(curl -s ${URL_VERSION} | jq -e -r '.supervisor')
 URL_APPARMOR_PROFILE="https://version.home-assistant.io/apparmor.txt"
 
+# reload systemd
+info "Reload systemd"
+systemctl daemon-reload
 
 # Restart NetworkManager
 info "Restarting NetworkManager"

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -51,7 +51,30 @@ if [[ "$(sysctl --values kernel.dmesg_restrict)" != "0" ]]; then
     echo "kernel.dmesg_restrict=0" >> /etc/sysctl.conf
 fi
 
+# If the hassio_supervisor service is running or exists, stop it 
+if [[ "$(systemctl is-active hassio-supervisor.service)" == "active" ]]; then
+    info "Stopping hassio_supervisor service"
+    systemctl stop hassio-supervisor.service
+fi
 
+# If the hassio_apparmor service is running or exists, stop it
+if [[ "$(systemctl is-active hassio-apparmor.service)" == "active" ]]; then
+    info "Stopping hassio_apparmor service"
+    systemctl stop hassio-apparmor.service
+fi
+
+# Check for existing hassio_supervisor container and destroy it
+if [[ "$(docker ps -aq -f name=hassio_supervisor)" ]]; then
+    # ensure the hassio_supervisor service is stopped
+    info "Removing existing hassio_supervisor container"
+    docker container rm --force hassio_supervisor > /dev/null
+fi
+
+# If docker is running, stop it
+if [[ "$(systemctl is-active docker.service)" == "active" ]]; then
+    info "Stopping Docker service"
+    systemctl stop docker.service
+fi
 
 dpkg-divert --package homeassistant-supervised --add --rename \
     --divert /etc/NetworkManager/NetworkManager.conf.real /etc/NetworkManager/NetworkManager.conf


### PR DESCRIPTION
Cleanup container and stop services before installing to avoid any possible conflicts or issues forcing the container to be recreated with the latest config 