### PR TITLE
Unmask system-resolved if needed

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -31,6 +31,11 @@ if [ "$(stat -c %a /etc/systemd/resolved.conf)" != "644" ]; then
     chmod 644 /etc/systemd/resolved.conf
 fi
 
+# Unmask systemd-resolved if needed
+if systemctl status systemd-resolved.service | grep -q 'masked'; then
+    sudo systemctl unmask systemd-resolved.service
+fi
+
 # Enable and restart systemd-resolved
 info "Enable systemd-resolved"
 systemctl enable systemd-resolved.service> /dev/null 2>&1;


### PR DESCRIPTION
Installation on my system (Debian 12.4) failed in the configuration phase of the debian package due to
systemd-resolved being masked.  This was from a fresh minimal installation of debian bookworm, by just following the home assistant supervised install readme.