### PR TITLE
Reorganize dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Step 1: Install the following dependencies with this command:
 ```bash
 apt install \
 apparmor \
+bluez \
 cifs-utils \
 curl \
 dbus \

--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -1,9 +1,10 @@
 Package: homeassistant-supervised
 Section: base
-Version: 1.7.0
+Version: 1.8.0
 Priority: optional
 Architecture: all
-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved | systemd (>=247.3-7+deb11), nfs-common, cifs-utils
+Pre-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved | systemd (>=247.3-7+deb11)
+Depends: bluez, cifs-utils, nfs-common
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised


### PR DESCRIPTION
Reorganize dependencies split Depends and Pre-Depends, use Pre-Depends for packages which need to be configured before the installer is ran and add `bluez` to the main dependency list 
As recommended in #360 