### PR TITLE
Drop Debian Bullseye

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: OS Version
       description: Please Insert the output of `lsb_release -d`
-      placeholder: Debian GNU/Linux 11 (bullseye)
+      placeholder: Debian GNU/Linux 12 (bookworm)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: System Information
       description: Please Insert the output of `uname -a`
-      placeholder: 'Linux ha-su-deb 5.10.0-9-amd64 #1 SMP Debian 5.10.70-1 (2021-09-30) x86_64 GNU/Linux'
+      placeholder: 'Linux ha 6.1.0-26-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.112-1 (2024-09-30) x86_64 GNU/Linux'
     validations:
       required: true
   - type: textarea
@@ -59,6 +59,7 @@ body:
         - raspberrypi3-64
         - raspberrypi4
         - raspberrypi4-64
+        - raspberrypi5-64
         - tinker
     validations:
       required: true

--- a/.github/workflows/build-deb-pr.yml
+++ b/.github/workflows/build-deb-pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4.2.0
       - name: Build Debian Package in Docker
         run: |
-          docker run --rm -v $(pwd):/tmp debian:bullseye-slim bash -c \
+          docker run --rm -v $(pwd):/tmp debian:bookworm-slim bash -c \
           "cd /tmp \
           && chmod 555 homeassistant-supervised/DEBIAN/p* \
           && dpkg-deb --build --root-owner-group homeassistant-supervised"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4.2.0
       - name: Build Debian Package in Docker
         run: |
-          docker run --rm -v $(pwd):/tmp debian:bullseye-slim bash -c \
+          docker run --rm -v $(pwd):/tmp debian:bookworm-slim bash -c \
           "cd /tmp \
           && chmod 555 homeassistant-supervised/DEBIAN/p* \
           && dpkg-deb --build --root-owner-group homeassistant-supervised"

--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: homeassistant-supervised
 Section: base
-Version: 1.8.0
+Version: 2.0.0
 Priority: optional
 Architecture: all
 Pre-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved

--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -3,7 +3,7 @@ Section: base
 Version: 1.8.0
 Priority: optional
 Architecture: all
-Pre-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved | systemd (>=247.3-7+deb11)
+Pre-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved
 Depends: bluez, cifs-utils, nfs-common
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -12,7 +12,7 @@ warn ""
 
 # Check if we are running on a supported OS
 BYPASS_OS_CHECK=${BYPASS_OS_CHECK:-false}
-supported_os=("Debian GNU/Linux 11 (bullseye)" "Debian GNU/Linux 12 (bookworm)")
+supported_os=("Debian GNU/Linux 12 (bookworm)")
 
 CURRENT_OS=$(lsb_release -d | awk -F"\t" '{print $2}')
 os_supported=false


### PR DESCRIPTION
I think now is the time to drop support for Debian Bullseye, I held off because of the privilege issues we were having in the past but I have not seen any issues pop up recently in regards to that and in my own testing it seems it has been solved by https://github.com/home-assistant/version/pull/370, https://github.com/home-assistant/supervisor/issues/4381 and https://github.com/home-assistant/version/pull/372. Thus I am now comfortable with dropping Debian 11 Bullseye