### PR TITLE
Add iproute2 and systemd-timesyncd as explicit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ bluez \
 cifs-utils \
 curl \
 dbus \
+iproute2 \
 jq \
 libglib2.0-bin \
 lsb-release \
@@ -30,6 +31,7 @@ network-manager \
 nfs-common \
 systemd-journal-remote \
 systemd-resolved \
+systemd-timesyncd \
 udisks2 \
 wget -y
 ```

--- a/homeassistant-supervised/DEBIAN/control
+++ b/homeassistant-supervised/DEBIAN/control
@@ -3,8 +3,8 @@ Section: base
 Version: 2.0.0
 Priority: optional
 Architecture: all
-Pre-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, os-agent, systemd-journal-remote, systemd-resolved
-Depends: bluez, cifs-utils, nfs-common
+Pre-Depends: curl, bash, docker-ce, dbus, network-manager, apparmor, jq, systemd, systemd-timesyncd, os-agent, systemd-journal-remote, systemd-resolved
+Depends: bluez, cifs-utils, nfs-common, iproute2
 Maintainer: Matheson Steplock <https://mathesonsteplock.ca/>
 Homepage: https://www.home-assistant.io/
 Description: Home Assistant Supervised


### PR DESCRIPTION
During postinst we use `ip`, hence make `iproute2` a dependency.

The `systemd-timesyncd` is a recommends dependency of the `systemd` package, hence it is being installed by default if not explicitly opted-out. However, Supervisor really relies on it nowadays, so make it an explicit dependency.

Fixes: #389