### PR TITLE
Use /var/lib/homeassistant as Supervisor data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ apt install ./homeassistant-supervised.deb
 
 ## Configuration
 
-The default path for our `$DATA_SHARE` is `/usr/share/hassio`.
+The default path for our `$DATA_SHARE` is `/var/lib/homeassistant` (used to be `/usr/share/hassio`).
 This path is used to store all home assistant related things.
 
 You can reconfigure this path during installation with

--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -120,7 +120,7 @@ case ${ARCH} in
 esac
 PREFIX=${PREFIX:-/usr}
 SYSCONFDIR=${SYSCONFDIR:-/etc}
-DATA_SHARE=${DATA_SHARE:-$PREFIX/share/hassio}
+DATA_SHARE=${DATA_SHARE:-/var/lib/homeassistant}
 CONFIG="${SYSCONFDIR}/hassio.json"
 cat > "${CONFIG}" <<- EOF
 {

--- a/homeassistant-supervised/usr/sbin/hassio-apparmor
+++ b/homeassistant-supervised/usr/sbin/hassio-apparmor
@@ -5,7 +5,7 @@ set -e
 CONFIG_FILE=%%HASSIO_CONFIG%%
 
 # Read configs
-DATA="$(jq --raw-output '.data // "/usr/share/hassio"' ${CONFIG_FILE})"
+DATA="$(jq --raw-output '.data // "/var/lib/homeassistant"' ${CONFIG_FILE})"
 PROFILES_DIR="${DATA}/apparmor"
 CACHE_DIR="${PROFILES_DIR}/cache"
 

--- a/homeassistant-supervised/usr/sbin/hassio-supervisor
+++ b/homeassistant-supervised/usr/sbin/hassio-supervisor
@@ -9,7 +9,7 @@ set -e
 CONFIG_FILE=%%HASSIO_CONFIG%%
 
 # Init supervisor
-SUPERVISOR_DATA="$(jq --raw-output '.data // "/usr/share/hassio"' ${CONFIG_FILE})"
+SUPERVISOR_DATA="$(jq --raw-output '.data // "/var/lib/homeassistant"' ${CONFIG_FILE})"
 SUPERVISOR_STARTUP_MARKER="/run/supervisor/startup-marker"
 SUPERVISOR_STARTSCRIPT_VERSION="${SUPERVISOR_DATA}/supervisor-version"
 SUPERVISOR_MACHINE="$(jq --raw-output '.machine' ${CONFIG_FILE})"


### PR DESCRIPTION
Instead of using /usr/share/hassio use /var/lib/homeassistant as Supervisor data directory. While the Supervisor data directory is a mixed bag of user and somewhat static files, /var/lib seems the better fit than /usr/local.

Fixes: #393