### PR TITLE
fix(postinst): handle cgroup switch on systems with /boot/cmdline.txt

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -188,8 +188,15 @@ then
         sed -i.bak 's/ systemd\.unified_cgroup_hierarchy=false//' /boot/firmware/cmdline.txt
         touch /var/run/reboot-required
     fi
+elif [ -f /boot/cmdline.txt ]
+then
+    if grep -q "systemd.unified_cgroup_hierarchy=false" /boot/cmdline.txt; then
+        info "Switching to cgroup v2"
+        sed -i.bak 's/ systemd\.unified_cgroup_hierarchy=false//' /boot/cmdline.txt
+        touch /var/run/reboot-required
+    fi
 else
-    warn "Could not find /etc/default/grub or /boot/firmware/cmdline.txt failed to switch to cgroup v1"
+    warn "Could not find /etc/default/grub or /boot/firmware/cmdline.txt or /boot/cmdline.txt failed to switch from cgroup v1 to cgroup v2 "
 fi
 info "Within a few minutes you will be able to reach Home Assistant at:"
 info "http://homeassistant.local:8123 or using the IP address of your"


### PR DESCRIPTION
Added logic to manage the switch to cgroup v2 on systems using /boot/cmdline.txt. This update ensures compatibility by checking for the presence of "systemd.unified_cgroup_hierarchy=false" and updating it, aligning system requirements, and prompting a reboot as necessary. Improved warning message for better clarity when neither configuration file is found.