### PR TITLE
Remove systemd-resolved as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ lsb-release \
 network-manager \
 nfs-common \
 systemd-journal-remote \
-systemd-resolved \
 systemd-timesyncd \
 udisks2 \
 wget -y


### PR DESCRIPTION
Debian ships with systemd-resolved. Running the apt command breaks the working config.

For details, see:
https://github.com/home-assistant/supervised-installer/issues/339#issuecomment-2838486491