### PR TITLE
Use os-release for version check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -12,7 +12,7 @@ body:
     id: os-version
     attributes:
       label: OS Version
-      description: Please Insert the output of `lsb_release -d`
+      description: Please run `hostnamectl` and insert the value after "Operating System"
       placeholder: Debian GNU/Linux 12 (bookworm)
     validations:
       required: true
@@ -20,7 +20,7 @@ body:
     id: uname
     attributes:
       label: System Information
-      description: Please Insert the output of `uname -a`
+      description: Please insert the output of `uname -a`
       placeholder: 'Linux ha 6.1.0-26-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.112-1 (2024-09-30) x86_64 GNU/Linux'
     validations:
       required: true

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -12,17 +12,20 @@ warn ""
 
 # Check if we are running on a supported OS
 BYPASS_OS_CHECK=${BYPASS_OS_CHECK:-false}
-supported_os=("Debian GNU/Linux 12 (bookworm)")
+supported_os_id="debian"
+supported_os_version_id=("12")
 
-CURRENT_OS=$(lsb_release -d | awk -F"\t" '{print $2}')
+source /etc/os-release
 os_supported=false
 
-for os in "${supported_os[@]}"; do
-    if [[ $os == "$CURRENT_OS" ]]; then
-        os_supported=true
-        break
-    fi
-done
+if [[ "$ID" == "$supported_os_id" ]]; then
+    for version in "${supported_os_version_id[@]}"; do
+        if [[ "$VERSION_ID" == "$version" ]]; then
+            os_supported=true
+            break
+        fi
+    done
+fi
 
 if [[ $os_supported == false ]]; then
     if [[ $BYPASS_OS_CHECK != "true" ]]; then


### PR DESCRIPTION
Debian dropped LSB support in 2015 (see https://wiki.debian.org/LSBInitScripts/DependencyBasedBoot). By default the command lsb_version seems to be still available, but the package lsb-release is not marked as essential, which means by Debian packaging policy it would need to be part of the package dependencies.

Replace it by checking the more modern /etc/os-release file.