### PR TITLE
Fix unsupported OS messages

### DIFF
--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -29,10 +29,10 @@ fi
 
 if [[ $os_supported == false ]]; then
     if [[ $BYPASS_OS_CHECK != "true" ]]; then
-        error "${CURRENT_OS} is not supported!"
+        error "${PRETTY_NAME} is not supported!"
     fi
     warn "Bypassing OS check..."
-    warn "${CURRENT_OS} is not supported!"
+    warn "${PRETTY_NAME} is not supported!"
     warn "Please DO NOT report issues regarding this OS!"
 fi
 


### PR DESCRIPTION
The move to `/etc/os-release` broke the error/warning messages. Use `PRETTY_NAME` sourced from `/etc/os-release`.