### PR TITLE
Use stable AppArmor by default

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -17,7 +17,7 @@ SERVICE_NM="NetworkManager.service"
 URL_CHECK_ONLINE="https://checkonline.home-assistant.io/online.txt"
 URL_VERSION="https://version.home-assistant.io/stable.json"
 HASSIO_VERSION=$(curl -s ${URL_VERSION} | jq -e -r '.supervisor')
-URL_APPARMOR_PROFILE="https://version.home-assistant.io/apparmor.txt"
+URL_APPARMOR_PROFILE="https://version.home-assistant.io/apparmor_stable.txt"
 
 # reload systemd
 info "Reload systemd"


### PR DESCRIPTION
Today, AppArmor profiles for Supervisor are distributed with the channel as suffix. The profile without a suffix is actually outdated and leads to Supervisor not being able to initialize udev and raising an "Unhealthy system - Not privileged" error (see https://github.com/home-assistant/supervisor/issues/4381). After the first update of Supervisor, or the reboot (due to https://github.com/home-assistant/supervisor/issues/4839), the error clears since the AppArmor profile is updated along with a Supervisor release. However, this makes sure that Supervised installation start with the proper AppArmor profile right after installation.