### PR TITLE
Make interactive CLI commands work

### DIFF
--- a/homeassistant-supervised/usr/bin/ha
+++ b/homeassistant-supervised/usr/bin/ha
@@ -1,10 +1,11 @@
-#!/usr/bin/env bash
-# shellcheck disable=SC2048,SC2086
+#!/bin/sh
+# ==============================================================================
+# HA utility
+# ==============================================================================
 
-if [ "$1" != "__complete" ]; then
-    use_tty="-t"
+if [ -t 1 ]; then
+        # stdout (fd 1) must be terminal, otherwise `-t` causes error
+        docker exec -it hassio_cli ha "$@"
 else
-    use_tty=""
+        docker exec -i hassio_cli ha "$@"
 fi
-
-docker exec ${use_tty} hassio_cli ha $*


### PR DESCRIPTION
The Home Assistant CLI (ha) has gained some interactive commands. Make them work by always running the docker exec interactively. Also use the same tty detection logic used in Home Assistant OS. This seems to work for bash completion as well.