### PR TITLE
Drop unsupported machines and architectures

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -48,19 +48,11 @@ body:
         - odroid-c2
         - odroid-c4
         - odroid-n2
-        - odroid-xu
-        - qemuarm
         - qemuarm-64
-        - qemux86
         - qemux86-64
-        - raspberrypi
-        - raspberrypi2
-        - raspberrypi3
         - raspberrypi3-64
-        - raspberrypi4
         - raspberrypi4-64
         - raspberrypi5-64
-        - tinker
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -83,23 +83,14 @@ apt install ./homeassistant-supervised.deb
 ## Supported Machine types
 
 - generic-x86-64
-- generic-aarch64
 - odroid-c2
 - odroid-c4
 - odroid-n2
-- odroid-xu
-- qemuarm
-- qemuarm-64
-- qemux86
+- qemuarm-64 (use this for any aarch64 machine)
 - qemux86-64
-- raspberrypi
-- raspberrypi2
-- raspberrypi3
-- raspberrypi4
 - raspberrypi3-64
 - raspberrypi4-64
 - raspberrypi5-64
-- tinker
 - khadas-vim3
 
 ## Configuration

--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -75,33 +75,9 @@ PRIMARY_INTERFACE=$(ip route | awk '/^default/ { print $5; exit }')
 IP_ADDRESS=$(ip -4 addr show dev "${PRIMARY_INTERFACE}" | awk '/inet / { sub("/.*", "", $2); print $2 }')
 
 case ${ARCH} in
-    "i386" | "i686")
-        MACHINE=${MACHINE:=qemux86}
-        HASSIO_DOCKER="${DOCKER_REPO}/i386-hassio-supervisor"
-    ;;
     "x86_64")
         MACHINE=${MACHINE:=qemux86-64}
         HASSIO_DOCKER="${DOCKER_REPO}/amd64-hassio-supervisor"
-    ;;
-    "arm" |"armv6l")
-        if [ -z "${MACHINE}" ]; then
-             db_input critical ha/machine-type || true
-             db_go || true
-             db_get ha/machine-type || true
-             MACHINE="${RET}"
-             db_stop
-        fi
-        HASSIO_DOCKER="${DOCKER_REPO}/armhf-hassio-supervisor"
-    ;;
-    "armv7l")
-        if [ -z "${MACHINE}" ]; then
-             db_input critical ha/machine-type || true
-             db_go || true
-             db_get ha/machine-type || true
-             MACHINE="${RET}"
-             db_stop
-        fi
-        HASSIO_DOCKER="${DOCKER_REPO}/armv7-hassio-supervisor"
     ;;
     "aarch64")
         if [ -z "${MACHINE}" ]; then

--- a/homeassistant-supervised/DEBIAN/preinst
+++ b/homeassistant-supervised/DEBIAN/preinst
@@ -38,7 +38,7 @@ fi
 
 # Check if we are running on a supported architecture
 ARCH=$(uname -m)
-if [[ ! "i386|i686|x86_64|arm|armv6l|armv7l|aarch64" == *"$ARCH"* ]]; then
+if [[ ! "x86_64|aarch64" == *"$ARCH"* ]]; then
     error "${ARCH} is not supported!"
 fi
 

--- a/homeassistant-supervised/DEBIAN/templates
+++ b/homeassistant-supervised/DEBIAN/templates
@@ -1,4 +1,4 @@
 Template: ha/machine-type
 Type: Select
-Choices: generic-x86-64, odroid-c2, odroid-c4, odroid-n2, odroid-xu, qemuarm, qemuarm-64, qemux86, qemux86-64, raspberrypi, raspberrypi2, raspberrypi3, raspberrypi4, raspberrypi3-64, raspberrypi4-64, raspberrypi5-64, tinker, khadas-vim3
+Choices: generic-x86-64, odroid-c2, odroid-c4, odroid-n2, qemuarm-64, qemux86-64, raspberrypi3-64, raspberrypi4-64, raspberrypi5-64, khadas-vim3
 Description: Select machine type


### PR DESCRIPTION
The deprecation period of the i386, armhf and armv7 architecture support has passed, and the Home Assistant project no longer publishes new images for these architectures. Remove support from the installer avoids new installation on these architectures.

Note that `generic-aarch64` was never a valid machine on Supervisor level: There is a `generic-aarch64` OS image, but it uses the `qemuarm-64` machine. This also update the README.md accordingly.

Related-to: #411