### PR TITLE
logind: Set InhibitDelayMaxSec=300 to allow Supervisor graceful shutdown

### DIFF
--- a/homeassistant-supervised/etc/systemd/logind.conf.d/hassio.conf
+++ b/homeassistant-supervised/etc/systemd/logind.conf.d/hassio.conf
@@ -1,0 +1,5 @@
+[Login]
+# Allow Supervisor enough time to gracefully stop all add-ons, Home Assistant
+# Core, and plugins before the system shuts down. Core alone can take 40+
+# seconds to stop; 300s gives enough headroom for a clean shutdown.
+InhibitDelayMaxSec=300


### PR DESCRIPTION
Supervisor takes a logind delay inhibitor lock on startup and releases it after gracefully stopping all add-ons, Home Assistant Core, and plugins. The default 5s window is far too short — Core alone can take 40+ seconds to stop. 300s gives enough headroom for a clean shutdown.

Mirrors this HAOS change: https://github.com/home-assistant/operating-system/pull/4577