### PR TITLE
Fix inconsistent spacing in arm/armv6l case pattern

### DIFF
--- a/homeassistant-supervised/DEBIAN/postinst
+++ b/homeassistant-supervised/DEBIAN/postinst
@@ -69,7 +69,7 @@ case ${ARCH} in
         MACHINE=${MACHINE:=qemux86-64}
         HASSIO_DOCKER="${DOCKER_REPO}/amd64-hassio-supervisor"
     ;;
-    "arm" |"armv6l")
+    "arm" | "armv6l")
         if [ -z "${MACHINE}" ]; then
              db_input critical ha/machine-type || true
              db_go || true


### PR DESCRIPTION
## Summary

- Fix missing space after `|` in the `arm | armv6l` case pattern in `postinst`
- Before: `"arm" |"armv6l")`
- After: `"arm" | "armv6l")`

Improves readability and makes spacing consistent with the rest of the `case` statement.

## Test plan
- [ ] Visual diff confirms only whitespace change
- [ ] No functional behavior change (bash ignores surrounding spaces in case patterns)